### PR TITLE
Fix error when saving term without template field

### DIFF
--- a/src/Taxonomies/Term.php
+++ b/src/Taxonomies/Term.php
@@ -44,7 +44,7 @@ class Term extends FileEntry
 
         $data = $this->data();
 
-        if (is_null($data['template'])) {
+        if (isset($data['template']) && is_null($data['template'])) {
             unset($data['template']);
         }
 


### PR DESCRIPTION
This fixes an `undefined array key` error that occurs when saving a term that does not have a template field.