### PR TITLE
Add separate config for terms

### DIFF
--- a/config/eloquent_driver.php
+++ b/config/eloquent_driver.php
@@ -57,6 +57,10 @@ return [
     'taxonomies' => [
         'driver' => 'eloquent',
         'model' =>  \Statamic\Eloquent\Taxonomies\TaxonomyModel::class,
-        'term_model' =>  \Statamic\Eloquent\Taxonomies\TermModel::class,
+    ],
+
+    'terms' => [
+        'driver' => 'eloquent',
+        'model' =>  \Statamic\Eloquent\Taxonomies\TermModel::class,
     ],
 ];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -82,6 +82,7 @@ class ServiceProvider extends AddonServiceProvider
         $this->registerRevisions();
         $this->registerStructures();
         $this->registerTaxonomies();
+        $this->registerTerms();
     }
 
     private function registerAssets()
@@ -250,20 +251,28 @@ class ServiceProvider extends AddonServiceProvider
         }
 
         Statamic::repository(TaxonomyRepositoryContract::class, TaxonomyRepository::class);
-        Statamic::repository(TermRepositoryContract::class, TermRepository::class);
-
-        $this->app->bind(TermQueryBuilder::class, function ($app) {
-            return new TermQueryBuilder(
-                $app['statamic.eloquent.taxonomies.term_model']::query()
-            );
-        });
-
-        $this->app->bind('statamic.eloquent.taxonomies.term_model', function () {
-            return config('statamic.eloquent_driver.taxonomies.term_model');
-        });
 
         $this->app->bind('statamic.eloquent.taxonomies.model', function () {
             return config('statamic.eloquent_driver.taxonomies.model');
+        });
+    }
+
+    public function registerTerms()
+    {
+        if (config('statamic.eloquent_driver.terms.driver', 'file') != 'eloquent') {
+            return;
+        }
+
+        Statamic::repository(TermRepositoryContract::class, TermRepository::class);
+
+        $this->app->bind('statamic.eloquent.terms.model', function () {
+            return config('statamic.eloquent_driver.terms.model');
+        });
+
+        $this->app->bind(TermQueryBuilder::class, function ($app) {
+            return new TermQueryBuilder(
+                $app['statamic.eloquent.terms.model']::query()
+            );
         });
     }
 

--- a/src/Taxonomies/Term.php
+++ b/src/Taxonomies/Term.php
@@ -40,7 +40,7 @@ class Term extends FileEntry
 
     public function toModel()
     {
-        $class = app('statamic.eloquent.taxonomies.term_model');
+        $class = app('statamic.eloquent.terms.model');
 
         $data = $this->data();
 


### PR DESCRIPTION
This adds a separate config for terms making it possible to store taxonomies in files while terms get saved to the database.