### PR TITLE
Fix typo in config name

### DIFF
--- a/src/Database/BaseMigration.php
+++ b/src/Database/BaseMigration.php
@@ -28,6 +28,6 @@ class BaseMigration extends Migration
      */
     protected function prefix(string $table): string
     {
-        return config('statamic.eloquent-driver.table_prefix', '').$table;
+        return config('statamic.eloquent_driver.table_prefix', '').$table;
     }
 }


### PR DESCRIPTION
Hi

I just found a little typo in the BaseMigration.