### PR TITLE
Allow to publish migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ If you're starting from scratch, we can use traditional incrementing integers fo
 
 - Delete `content/collections/pages/home.md`
 - Change the structure `tree` in `content/collections/pages.yaml` to `{}`.
+- Run `php artisan vendor:publish --provider="Statamic\Eloquent\ServiceProvider" --tag=migrations"`.
 - Run `php artisan vendor:publish --tag="statamic-eloquent-entries-table"`.
 - Run `php artisan migrate`.
 
@@ -32,6 +33,7 @@ If you're starting from scratch, we can use traditional incrementing integers fo
 If you're planning to use existing content, we can use the existing UUIDs. This will prevent you from needing to update any data or relationships.
 
 - In the `config/statamic/eloquent-driver.php` file, change `model` to `UuidEntryModel`.
+- Run `php artisan vendor:publish --provider="Statamic\Eloquent\ServiceProvider" --tag=migrations"`.
 - Run `php artisan vendor:publish --tag="statamic-eloquent-entries-table-with-string-ids"`.
 - Run `php artisan migrate`.
 - Import entries into database with `php please eloquent:import-entries`.

--- a/database/migrations/create_asset_containers_table.php.stub
+++ b/database/migrations/create_asset_containers_table.php.stub
@@ -4,31 +4,21 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 
-class CreateFormsTable extends Migration
-{
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
+return new class extends Migration {
     public function up()
     {
-        Schema::create($this->prefix('forms'), function (Blueprint $table) {
+        Schema::create($this->prefix('asset_containers'), function (Blueprint $table) {
             $table->id();
             $table->string('handle');
             $table->string('title');
+            $table->string('disk');
             $table->json('settings')->nullable();
             $table->timestamps();
         });
     }
 
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
     public function down()
     {
-        Schema::dropIfExists($this->prefix('forms'));
+        Schema::dropIfExists($this->prefix('asset_containers'));
     }
-}
+};

--- a/database/migrations/create_asset_table.php.stub
+++ b/database/migrations/create_asset_table.php.stub
@@ -4,13 +4,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 
-class CreateAssetTable extends Migration
-{
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
+return new class extends Migration {
     public function up()
     {
         Schema::create($this->prefix('assets_meta'), function (Blueprint $table) {
@@ -21,13 +15,9 @@ class CreateAssetTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
+
     public function down()
     {
         Schema::dropIfExists($this->prefix('assets_meta'));
     }
-}
+};

--- a/database/migrations/create_blueprints_table.php.stub
+++ b/database/migrations/create_blueprints_table.php.stub
@@ -5,13 +5,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 
-class CreateBlueprintsTable extends Migration
-{
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
+return new class extends Migration {
     public function up()
     {
         Schema::create($this->prefix('blueprints'), function (Blueprint $table) {
@@ -25,11 +19,6 @@ class CreateBlueprintsTable extends Migration
         $this->seedDefaultBlueprint();
     }
 
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
     public function down()
     {
         Schema::dropIfExists($this->prefix('blueprints'));
@@ -79,4 +68,4 @@ class CreateBlueprintsTable extends Migration
             'created_at' => Carbon::now(),
         ]);
     }
-}
+};

--- a/database/migrations/create_collections_table.php.stub
+++ b/database/migrations/create_collections_table.php.stub
@@ -4,32 +4,20 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 
-class CreateAssetContainersTable extends Migration
-{
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
+return new class extends Migration {
     public function up()
     {
-        Schema::create($this->prefix('asset_containers'), function (Blueprint $table) {
+        Schema::create($this->prefix('collections'), function (Blueprint $table) {
             $table->id();
             $table->string('handle');
             $table->string('title');
-            $table->string('disk');
             $table->json('settings')->nullable();
             $table->timestamps();
         });
     }
 
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
     public function down()
     {
-        Schema::dropIfExists($this->prefix('asset_containers'));
+        Schema::dropIfExists($this->prefix('collections'));
     }
-}
+};

--- a/database/migrations/create_entries_table.php.stub
+++ b/database/migrations/create_entries_table.php.stub
@@ -4,19 +4,13 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 
-class CreateEntriesTableWithStringIds extends Migration
-{
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
+return new class extends Migration {
     public function up()
     {
         Schema::create($this->prefix('entries'), function (Blueprint $table) {
-            $table->string('id');
+            $table->increments('id');
             $table->string('site');
-            $table->string('origin_id')->nullable();
+            $table->unsignedInteger('origin_id')->nullable();
             $table->boolean('published')->default(true);
             $table->string('status');
             $table->string('slug')->nullable();
@@ -28,13 +22,8 @@ class CreateEntriesTableWithStringIds extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
     public function down()
     {
         Schema::dropIfExists($this->prefix('entries'));
     }
-}
+};

--- a/database/migrations/create_entries_table_with_string_ids.php.stub
+++ b/database/migrations/create_entries_table_with_string_ids.php.stub
@@ -4,19 +4,13 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 
-class CreateEntriesTable extends Migration
-{
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
+return new class extends Migration {
     public function up()
     {
         Schema::create($this->prefix('entries'), function (Blueprint $table) {
-            $table->increments('id');
+            $table->string('id');
             $table->string('site');
-            $table->unsignedInteger('origin_id')->nullable();
+            $table->string('origin_id')->nullable();
             $table->boolean('published')->default(true);
             $table->string('status');
             $table->string('slug')->nullable();
@@ -28,13 +22,8 @@ class CreateEntriesTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
     public function down()
     {
         Schema::dropIfExists($this->prefix('entries'));
     }
-}
+};

--- a/database/migrations/create_fieldsets_table.php.stub
+++ b/database/migrations/create_fieldsets_table.php.stub
@@ -4,13 +4,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 
-class CreateFieldsetsTable extends Migration
-{
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
+return new class extends Migration {
     public function up()
     {
         Schema::create($this->prefix('fieldsets'), function (Blueprint $table) {
@@ -21,13 +15,8 @@ class CreateFieldsetsTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
     public function down()
     {
         Schema::dropIfExists($this->prefix('fieldsets'));
     }
-}
+};

--- a/database/migrations/create_form_submissions_table.php.stub
+++ b/database/migrations/create_form_submissions_table.php.stub
@@ -4,13 +4,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 
-class CreateFormSubmissionsTable extends Migration
-{
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
+return new class extends Migration {
     public function up()
     {
         Schema::create($this->prefix('form_submissions'), function (Blueprint $table) {
@@ -21,13 +15,8 @@ class CreateFormSubmissionsTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
     public function down()
     {
         Schema::dropIfExists($this->prefix('form_submissions'));
     }
-}
+};

--- a/database/migrations/create_forms_table.php.stub
+++ b/database/migrations/create_forms_table.php.stub
@@ -4,16 +4,10 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 
-class CreateCollectionsTable extends Migration
-{
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
+return new class extends Migration {
     public function up()
     {
-        Schema::create($this->prefix('collections'), function (Blueprint $table) {
+        Schema::create($this->prefix('forms'), function (Blueprint $table) {
             $table->id();
             $table->string('handle');
             $table->string('title');
@@ -22,13 +16,8 @@ class CreateCollectionsTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
     public function down()
     {
-        Schema::dropIfExists($this->prefix('collections'));
+        Schema::dropIfExists($this->prefix('forms'));
     }
-}
+};

--- a/database/migrations/create_globals_table.php.stub
+++ b/database/migrations/create_globals_table.php.stub
@@ -4,13 +4,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 
-class CreateGlobalsTable extends Migration
-{
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
+return new class extends Migration {
     public function up()
     {
         Schema::create($this->prefix('global_sets'), function (Blueprint $table) {
@@ -22,13 +16,8 @@ class CreateGlobalsTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
     public function down()
     {
         Schema::dropIfExists($this->prefix('global_sets'));
     }
-}
+};

--- a/database/migrations/create_navigation_trees_table.php.stub
+++ b/database/migrations/create_navigation_trees_table.php.stub
@@ -4,13 +4,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 
-class CreateNavigationTreesTable extends Migration
-{
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
+return new class extends Migration {
     public function up()
     {
         Schema::create($this->prefix('trees'), function (Blueprint $table) {
@@ -24,13 +18,8 @@ class CreateNavigationTreesTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
     public function down()
     {
         Schema::dropIfExists($this->prefix('trees'));
     }
-}
+};

--- a/database/migrations/create_navigations_table.php.stub
+++ b/database/migrations/create_navigations_table.php.stub
@@ -4,13 +4,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 
-class CreateNavigationsTable extends Migration
-{
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
+return new class extends Migration {
     public function up()
     {
         Schema::create($this->prefix('navigations'), function (Blueprint $table) {
@@ -25,13 +19,8 @@ class CreateNavigationsTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
     public function down()
     {
         Schema::dropIfExists($this->prefix('navigations'));
     }
-}
+};

--- a/database/migrations/create_revisions_table.php.stub
+++ b/database/migrations/create_revisions_table.php.stub
@@ -4,13 +4,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 
-class CreateRevisionsTable extends Migration
-{
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
+return new class extends Migration {
     public function up()
     {
         Schema::create($this->prefix('revisions'), function (Blueprint $table) {
@@ -24,13 +18,9 @@ class CreateRevisionsTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
+
     public function down()
     {
         Schema::dropIfExists($this->prefix('revisions'));
     }
-}
+};

--- a/database/migrations/create_taxonomies_table.php.stub
+++ b/database/migrations/create_taxonomies_table.php.stub
@@ -4,13 +4,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 
-class CreateTaxonomiesTable extends Migration
-{
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
+return new class extends Migration {
     public function up()
     {
         Schema::create($this->prefix('taxonomies'), function (Blueprint $table) {
@@ -32,4 +26,4 @@ class CreateTaxonomiesTable extends Migration
     {
         Schema::dropIfExists($this->prefix('taxonomies'));
     }
-}
+};

--- a/database/migrations/create_terms_table.php.stub
+++ b/database/migrations/create_terms_table.php.stub
@@ -4,13 +4,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Eloquent\Database\BaseMigration as Migration;
 
-class CreateTermsTable extends Migration
-{
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
+return new class extends Migration {
     public function up()
     {
         Schema::create($this->prefix('taxonomy_terms'), function (Blueprint $table) {
@@ -24,13 +18,8 @@ class CreateTermsTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
     public function down()
     {
         Schema::dropIfExists($this->prefix('taxonomy_terms'));
     }
-}
+};

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -35,6 +35,8 @@ class ServiceProvider extends AddonServiceProvider
 {
     protected $config = false;
 
+    protected $migrationCount = 0;
+
     public function boot()
     {
         parent::boot();
@@ -50,11 +52,27 @@ class ServiceProvider extends AddonServiceProvider
         $this->publishes([$config => config_path('statamic/eloquent_driver.php')], 'statamic-eloquent-config');
 
         $this->publishes([
-            __DIR__.'/../database/publish/create_entries_table.php' => $this->migrationsPath('create_entries_table'),
+            __DIR__.'/../database/migrations/create_taxonomies_table.php.stub' => $this->migrationsPath('create_taxonomies_table.php'),
+            __DIR__.'/../database/migrations/create_terms_table.php.stub' => $this->migrationsPath('create_terms_table.php'),
+            __DIR__.'/../database/migrations/create_globals_table.php.stub' => $this->migrationsPath('create_globals_table.php'),
+            __DIR__.'/../database/migrations/create_navigations_table.php.stub' => $this->migrationsPath('create_navigations_table.php'),
+            __DIR__.'/../database/migrations/create_navigation_trees_table.php.stub' => $this->migrationsPath('create_navigation_trees_table.php'),
+            __DIR__.'/../database/migrations/create_collections_table.php.stub' => $this->migrationsPath('create_collections_table.php'),
+            __DIR__.'/../database/migrations/create_blueprints_table.php.stub' => $this->migrationsPath('create_blueprints_table.php'),
+            __DIR__.'/../database/migrations/create_fieldsets_table.php.stub' => $this->migrationsPath('create_fieldsets_table.php'),
+            __DIR__.'/../database/migrations/create_forms_table.php.stub' => $this->migrationsPath('create_forms_table.php'),
+            __DIR__.'/../database/migrations/create_form_submissions_table.php.stub' => $this->migrationsPath('create_form_submissions_table.php'),
+            __DIR__.'/../database/migrations/create_asset_containers_table.php.stub' => $this->migrationsPath('create_asset_containers_table.php'),
+            __DIR__.'/../database/migrations/create_asset_table.php.stub' => $this->migrationsPath('create_asset_table.php'),
+            __DIR__.'/../database/migrations/create_revisions_table.php.stub' => $this->migrationsPath('create_revisions_table.php'),
+        ], 'migrations');
+
+        $this->publishes([
+            __DIR__.'/../database/migrations/create_entries_table.php.stub' => $this->migrationsPath('create_entries_table'),
         ], 'statamic-eloquent-entries-table');
 
         $this->publishes([
-            __DIR__.'/../database/publish/create_entries_table_with_string_ids.php' => $this->migrationsPath('create_entries_table_with_string_ids'),
+            __DIR__.'/../database/migrations/create_entries_table_with_string_ids.php.stub' => $this->migrationsPath('create_entries_table_with_string_ids'),
         ], 'statamic-eloquent-entries-table-with-string-ids');
 
         $this->commands([
@@ -276,8 +294,6 @@ class ServiceProvider extends AddonServiceProvider
 
     protected function migrationsPath($filename)
     {
-        $date = date('2021_05_16_160811');
-
-        return database_path("migrations/{$date}_{$filename}.php");
+        return database_path('migrations/'.date('Y_m_d_His', time() + (++$this->migrationCount + 60))."_{$filename}.php");
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,6 +12,22 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
 
     protected $shouldUseStringEntryIds = false;
 
+    protected $baseMigrations = [
+        __DIR__.'/../database/migrations/create_taxonomies_table.php.stub',
+        __DIR__.'/../database/migrations/create_terms_table.php.stub',
+        __DIR__.'/../database/migrations/create_globals_table.php.stub',
+        __DIR__.'/../database/migrations/create_navigations_table.php.stub',
+        __DIR__.'/../database/migrations/create_navigation_trees_table.php.stub',
+        __DIR__.'/../database/migrations/create_collections_table.php.stub',
+        __DIR__.'/../database/migrations/create_blueprints_table.php.stub',
+        __DIR__.'/../database/migrations/create_fieldsets_table.php.stub',
+        __DIR__.'/../database/migrations/create_forms_table.php.stub',
+        __DIR__.'/../database/migrations/create_form_submissions_table.php.stub',
+        __DIR__.'/../database/migrations/create_asset_containers_table.php.stub',
+        __DIR__.'/../database/migrations/create_asset_table.php.stub',
+        __DIR__.'/../database/migrations/create_revisions_table.php.stub',
+    ];
+
     protected function setUp(): void
     {
         require_once __DIR__.'/ConsoleKernel.php';
@@ -26,9 +42,9 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         }
 
         if ($this->shouldUseStringEntryIds) {
-            $this->loadMigrationsForUUIDEntries();
+            $this->runMigrationsForUUIDEntries();
         } else {
-            $this->loadMigrationsForIncrementingEntries();
+            $this->runMigrationsForIncrementingEntries();
         }
     }
 
@@ -172,17 +188,27 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             : parent::assertRegExp($pattern, $string, $message);
     }
 
-    public function loadMigrationsForIncrementingEntries()
+    public function runBaseMigrations()
     {
-        $this->artisan('vendor:publish --tag="statamic-eloquent-entries-table"');
-        $this->loadMigrationsFrom('../database/migrations');
-        $this->artisan('migrate');
+        foreach ($this->baseMigrations as $migration) {
+            $migration = require $migration;
+            $migration->up();
+        }
     }
 
-    public function loadMigrationsForUUIDEntries()
+    public function runMigrationsForIncrementingEntries()
     {
-        $this->artisan('vendor:publish --tag="statamic-eloquent-entries-table-with-string-ids"');
-        $this->loadMigrationsFrom('../database/migrations');
-        $this->artisan('migrate');
+        $this->runBaseMigrations();
+
+        $migration = require __DIR__.'/../database/migrations/create_entries_table.php.stub';
+        $migration->up();
+    }
+
+    public function runMigrationsForUUIDEntries()
+    {
+        $this->runBaseMigrations();
+
+        $migration = require __DIR__.'/../database/migrations/create_entries_table_with_string_ids.php.stub';
+        $migration->up();
     }
 }


### PR DESCRIPTION
Hi

As I am migration an older project where I used my previous fork of the eloquent-driver I run into issues when migrations will be loaded automatically.

Because I already have a table `collections`(and others) migrations can't no longer be run.

I've seen this method in many other Laravel packages and thought I refactor the migrations to stubs and let them be published explicitly by the developer. This also brings more flexibility for e.g. add own columns and more.

I've fixed the tests where this change caused some errors but not want to fix the other failing ones as this would blow up this PR.

Hope you like it.

