### PR TITLE
Bring back file submissions for Form migrations

### DIFF
--- a/src/Commands/ImportForms.php
+++ b/src/Commands/ImportForms.php
@@ -7,6 +7,7 @@ use Statamic\Console\RunsInPlease;
 use Statamic\Contracts\Forms\Form as FormContract;
 use Statamic\Contracts\Forms\FormRepository as FormRepositoryContract;
 use Statamic\Eloquent\Forms\Form;
+use Statamic\Eloquent\Import\FormSubmissions;
 use Statamic\Forms\FormRepository;
 use Statamic\Statamic;
 
@@ -59,7 +60,7 @@ class ImportForms extends Command
             $model = $form->toModel();
             $model->save();
 
-            $form->fileSubmissions()->each(function ($submission) use ($model) {
+            FormSubmissions::fileSubmissionsForForm($form)->each(function ($submission) use ($model) {
                 $model->submissions()->create([
                     'created_at' => $submission->date(),
                     'data' => $submission->data(),

--- a/src/Import/FormSubmissions.php
+++ b/src/Import/FormSubmissions.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Statamic\Eloquent\Import;
+
+use Statamic\Contracts\Forms\Form;
+use Statamic\Facades\File;
+use Statamic\Facades\Folder;
+use Statamic\Facades\YAML;
+
+class FormSubmissions
+{
+    public static function fileSubmissionsForForm(Form $form)
+    {
+        $path = config('statamic.forms.submissions') . '/' . $form->handle();
+
+        return collect(Folder::getFilesByType($path, 'yaml'))->map(function ($file) use ($form) {
+            return $form->makeSubmission()
+                ->id(pathinfo($file)['filename'])
+                ->data(YAML::parse(File::get($file)));
+        });
+    }
+}


### PR DESCRIPTION
Hi

To migrate Forms fileSubmissions needs to be places into the new Model. Otherwise the following error will occur:

```
Too few arguments to function Statamic\Data\AbstractAugmented::get(), 0 passed in /Users/okaufmann/Code/novu/hepverlag-cms/vendor/statamic/cms/src/Data/AbstractAugmented.php on line 52 and exactly 1 expected
```




